### PR TITLE
user.sh的用户名过滤

### DIFF
--- a/lib/user.sh
+++ b/lib/user.sh
@@ -25,7 +25,7 @@ L2TPD_CFG_FILE=/etc/xl2tpd/xl2tpd.conf
 BASEDIR=$(dirname $0)
 
 getall() {
-    cat $L2TPD_CFG_FILE | grep lac | sed 's/\[lac zju-l2tp-//' | sed 's/\]//'
+    cat $L2TPD_CFG_FILE | grep 'lac zju-l2tp-' | sed 's/\[lac zju-l2tp-//' | sed 's/\]//'
 }
 
 edituser() {


### PR DESCRIPTION
etc/xl2tpd/xl2tpd.conf文件中可能会有其他软件留下的账户名，在我的电脑上就有"[lac zjuvpn]"，用grep 'lac zju-l2tp-'将他们过滤掉。
