### PR TITLE
Add compatibility for ppp version 2.5.0

### DIFF
--- a/lib/xl2tpd.sh
+++ b/lib/xl2tpd.sh
@@ -143,14 +143,18 @@ xl2tpd_waituser() {
         fi
         echo -n > $PPP_LOG_FILE
 
-        pid="/var/run/ppp-${LAC_NAME}.pid"
-        if [ -e $pid ]; then
-            ppp=$(cat $pid | grep ppp)
-            if ip addr show | grep "inet.*${ppp}" > /dev/null; then
-                ip addr show | grep "inet.*${ppp}" | sed 's/^ */[VPN] /'
-                return
+        for pid in "/var/run/ppp-${LAC_NAME}.pid" \
+                   "/var/run/pppdppp-${LAC_NAME}.pid" \
+                   "/var/run/pppd/ppp-${LAC_NAME}.pid"; do
+            if [ -e $pid ]; then
+                ppp=$(cat $pid | grep ppp)
+                if ip addr show | grep "inet.*${ppp}" > /dev/null; then
+                    ip addr show | grep "inet.*${ppp}" | sed 's/^ */[VPN] /'
+                    return
+                fi
+                break
             fi
-        fi
+        done
 
     done
 


### PR DESCRIPTION
ppp pid file has become `/var/run/pppd/ppp-<linkname>.pid` since version 2.5.0. However, due to a [bug](https://github.com/ppp-project/ppp/pull/427), it is `/var/run/pppdppp-<linkname>.pid`.
This pr may fix "Fail to bring up ppp, timeout" bugs like [issue#68](https://github.com/QSCTech/zjunet/issues/68).