### PR TITLE
replace deprecated apt-key in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you meet any problem during or after the installation, check Troubleshooting 
 2. Run these command.
 
 ``` bash
-curl https://mirrors.zju.edu.cn/openzjunet/zjumirrors.pgp | sudo apt-key add -
+curl https://mirrors.zju.edu.cn/openzjunet/zjumirrors.pgp | sudo tee /etc/apt/trusted.gpg.d/zjumirrors.asc
 curl https://mirrors.zju.edu.cn/openzjunet/zjunet.list | sudo tee /etc/apt/sources.list.d/zjunet.list
 sudo apt-get update
 sudo apt-get install zjunet

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,7 +39,7 @@
 2. 依次输入并执行下列命令：
 
 ``` bash
-curl https://mirrors.zju.edu.cn/openzjunet/zjumirrors.pgp | sudo apt-key add -
+curl https://mirrors.zju.edu.cn/openzjunet/zjumirrors.pgp | sudo tee /etc/apt/trusted.gpg.d/zjumirrors.asc
 curl https://mirrors.zju.edu.cn/openzjunet/zjunet.list | sudo tee /etc/apt/sources.list.d/zjunet.list
 sudo apt-get update
 sudo apt-get install zjunet


### PR DESCRIPTION
https://manpages.debian.org/testing/apt/apt-key.8.en.html

> apt-key will last be available in Debian 11 and Ubuntu 22.04.

> Note: Instead of using this command a keyring should be placed directly in the /etc/apt/trusted.gpg.d/ directory with a descriptive name and either "gpg" or "asc" as file extension.